### PR TITLE
MapR Sandbox 5.2, Spark 1.6.1

### DIFF
--- a/spark-distributions/MapR-Sandbox-for-Hadoop.adoc
+++ b/spark-distributions/MapR-Sandbox-for-Hadoop.adoc
@@ -1,9 +1,9 @@
 == MapR Sandbox for Hadoop
 
-https://www.mapr.com/products/product-overview/apache-spark[MapR Sandbox for Hadoop] is a Spark distribution from MapR.
+https://www.mapr.com/products/mapr-sandbox-hadoop[MapR Sandbox for Hadoop] is a Spark distribution from MapR.
 
 > The MapR Sandbox for Hadoop is a fully-functional single-node cluster that gently introduces business analysts, current and aspiring Hadoop developers, and administrators (database, system, and Hadoop) to the big data promises of Hadoop and its ecosystem. Use the sandbox to experiment with Hadoop technologies using the MapR Control System (MCS) and Hue.
 
-The latest version of MapR Sandbox for Hadoop 5.1 uses Spark **1.5.2** and is _completely_ unsuitable for any Spark development (given how old the Spark version is used in the box).
+The latest version of MapR (5.2) Sandbox with Hadoop 2.7 uses **Spark 1.6.1** and is available as a VMware or VirtualBox VM.
 
-The documentation is available at http://maprdocs.mapr.com/51/.
+The documentation is available at http://maprdocs.mapr.com/home/


### PR DESCRIPTION
Update version MapR Sandbox 5.1 -> 5.2 ,Spark 1.5.2 ->  1.6.1, documentation links and provide direct link to the mapr-sandbox page.
